### PR TITLE
Add extra choices guide question types

### DIFF
--- a/src/choices-guide/component/choices-guide-result.jsx
+++ b/src/choices-guide/component/choices-guide-result.jsx
@@ -80,6 +80,8 @@ export default class OpenStadComponentChoicesGuideResult extends OpenStadCompone
       scrollToLogin,
       questionGroupId: this.config.questionGroupId,
     };
+    
+    this.form = null;
 
   }
 
@@ -342,7 +344,7 @@ export default class OpenStadComponentChoicesGuideResult extends OpenStadCompone
     let previousNextButtonsHTML = null;
     if (self.config.submission.type == 'form') {
       formHTML = (
-        <OpenStadComponentForms.Form config={ self.config.submission.form } onChange={self.onFormChange} ref={function(el) { self.form = el; }}/>
+        <OpenStadComponentForms.Form config={ self.config.submission.form } onChange={self.onFormChange} ref={function(el) { if (el != null) { self.form = el;} }}/>
       );
 
       if (requireLogin) {

--- a/src/choices-guide/component/choices-guide.jsx
+++ b/src/choices-guide/component/choices-guide.jsx
@@ -80,8 +80,6 @@ export default class OpenStadComponentChoicesGuide extends OpenStadComponent {
 
   fetchData() {
 
-    self = this;
-
     let self = this;
     fetchChoicesGuide({ config: self.config })
       .then((data) => {
@@ -254,7 +252,7 @@ export default class OpenStadComponentChoicesGuide extends OpenStadComponent {
 
 		var event = new window.CustomEvent('osc-choices-click', { detail: {} });
 		document.dispatchEvent(event);
-    
+  
   }
 
   render() {

--- a/src/choices-guide/component/choices.jsx
+++ b/src/choices-guide/component/choices.jsx
@@ -46,7 +46,9 @@ export default class OpenStadComponentChoices extends OpenStadComponent {
 
     let scores = {};
     self.choiceElements.forEach((choiceElement) => {
-      scores[choiceElement.config.divId] = choiceElement.calculateScore(answers);
+      if (choiceElement !== null) {
+        scores[choiceElement.config.divId] = choiceElement.calculateScore(answers);
+      }
     });
 
     // for plane: calculate position
@@ -65,7 +67,7 @@ export default class OpenStadComponentChoices extends OpenStadComponent {
               planePos[dimension] += parseInt(entry[dimension]) || 0;
               lengths[dimension]++
             }
-          });        
+          });
         });
         planePos.x = lengths.x ? parseInt(planePos.x / lengths.x) : undefined;
         planePos.y = lengths.y ? parseInt(planePos.y / lengths.y) : undefined;

--- a/src/choices-guide/component/edit/form.jsx
+++ b/src/choices-guide/component/edit/form.jsx
@@ -207,6 +207,7 @@ export default class OpenStadComponentChoicesGuideForm extends OpenStadComponent
         currentTarget.dimensions = question.dimensions;
         currentTarget.values = question.values;
         currentTarget.validation = question.validation ? question.validation : {};
+        currentTarget.extraConfig = question.extraConfig ? question.extraConfig : {};
         currentTarget.seqnr = typeof question.seqnr != 'undefined' ? question.seqnr : ( questionGroup.questions && questionGroup.questions[questionGroup.questions.length - 1] && parseInt(questionGroup.questions[questionGroup.questions.length - 1].seqnr) + 10 || 10 );
         break;
 
@@ -335,7 +336,8 @@ export default class OpenStadComponentChoicesGuideForm extends OpenStadComponent
             dimensions: self.state.currentTarget.dimensions,
             values: self.state.currentTarget.values,
             seqnr: self.state.currentTarget.seqnr,
-            validation: self.state.currentTarget.validation
+            validation: self.state.currentTarget.validation,
+            extraConfig: self.state.currentTarget.extraConfig
           };
           try {
             body.values = JSON.parse(body.values)

--- a/src/choices-guide/component/edit/overview.jsx
+++ b/src/choices-guide/component/edit/overview.jsx
@@ -14,9 +14,9 @@ export default class ChoiceForm extends OpenStadComponent {
 
     // mutiple questionGroups is not quite ready and is therefore turned of in the interface
     let newGroupButtonHTML = null;
-    if ( !self.props.questionGroups || self.props.questionGroups.length < 1 ) {
+    //if ( !self.props.questionGroups || self.props.questionGroups.length < 1 ) {
       newGroupButtonHTML = <a href="#" onClick={event => self.props.setCurrentForm({ what: 'question-group' })}>Nieuwe vraaggroep</a>
-    }
+    //}
 
     return (
           <div className="osc-overview">

--- a/src/choices-guide/component/edit/question-form.jsx
+++ b/src/choices-guide/component/edit/question-form.jsx
@@ -314,7 +314,7 @@ export default class QuestionForm extends OpenStadComponent {
         <OpenStadComponentForms.Select config={{ choices: [{ value: "", description: "Maak een keuze" },/*{ value: "continuous", description: "continue" },*/{ value: "a-to-b", description: "van a naar b slider" },/*{ value: "enum-buttons", description: "multiple choice - buttons" }*/,{ value: "enum-radio", description: "Enkele keuze vraag" }, { value: "input", description: "Eenvoudige tekstinput" }, { value: "textarea", description: "Groot tekstveld" }, { value: "multiple-choice", description: "Meerkeuze vraag" }], required: true  }} value={ self.props.currentTarget.type } onChange={ data => self.handleFieldChange({ type: data.value }) } ref={el => self.typeField = el}/>
   
         {
-          ['enum-radio', 'multiple-choice', 'input', 'textarea'].includes(self.props.currentTarget.type) &&
+          ['enum-radio', 'input', 'textarea'].includes(self.props.currentTarget.type) &&
           <div>
             <h3>Verplicht veld?</h3>
             <OpenStadComponentForms.Select config={{choices: [{value: "false", description: "Nee"}, {value: "true", description: "Ja"}]}} value={self.props.currentTarget.validation && self.props.currentTarget.validation.required} onChange={data => self.handleFieldChange({validation: {required: data.value}})} />

--- a/src/choices-guide/component/edit/question-form.jsx
+++ b/src/choices-guide/component/edit/question-form.jsx
@@ -116,6 +116,16 @@ export default class QuestionForm extends OpenStadComponent {
         parsedData = {validation: {minLength: data.validation.minLength}}
       } else if (data.validation.hasOwnProperty('maxLength')) {
         parsedData = {validation: {maxLength: data.validation.maxLength}}
+      } else if (data.validation.hasOwnProperty('minChoices')) {
+          parsedData = {validation: {minChoices: data.validation.minChoices}}
+      } else if (data.validation.hasOwnProperty('maxChoices')) {
+        parsedData = {validation: {maxChoices: data.validation.maxChoices}}
+      }
+    }
+    
+    if (typeof data.extraConfig != 'undefined') {
+      if (data.extraConfig.hasOwnProperty('showOther')) {
+        parsedData = {extraConfig: {showOther: data.extraConfig.showOther === 'true' ? 'true' : 'false'}}
       }
     }
     
@@ -301,7 +311,7 @@ export default class QuestionForm extends OpenStadComponent {
         <OpenStadComponentForms.ImageUpload key="i1" config={{ as: 'json', imageserver: self.config.image.server }} value={self.props.currentTarget.images} onChange={ data => self.props.onChange({ images: data.value }) } ref={el => self.imagesField = el}/>
 
         <h3>Type vraag</h3>
-        <OpenStadComponentForms.Select config={{ choices: [{ value: "", description: "Maak een keuze" },/*{ value: "continuous", description: "continue" },*/{ value: "a-to-b", description: "van a naar b slider" },/*{ value: "enum-buttons", description: "multiple choice - buttons" }*/,{ value: "enum-radio", description: "radio buttons" }, { value: "input", description: "eenvoudige tekstinput" }, { value: "textarea", description: "groot tekstveld" }, { value: "multiple-choice", description: "multiple choice" }], required: true  }} value={ self.props.currentTarget.type } onChange={ data => self.handleFieldChange({ type: data.value }) } ref={el => self.typeField = el}/>
+        <OpenStadComponentForms.Select config={{ choices: [{ value: "", description: "Maak een keuze" },/*{ value: "continuous", description: "continue" },*/{ value: "a-to-b", description: "van a naar b slider" },/*{ value: "enum-buttons", description: "multiple choice - buttons" }*/,{ value: "enum-radio", description: "Enkele keuze vraag" }, { value: "input", description: "Eenvoudige tekstinput" }, { value: "textarea", description: "Groot tekstveld" }, { value: "multiple-choice", description: "Meerkeuze vraag" }], required: true  }} value={ self.props.currentTarget.type } onChange={ data => self.handleFieldChange({ type: data.value }) } ref={el => self.typeField = el}/>
   
         {
           ['enum-radio', 'multiple-choice', 'input', 'textarea'].includes(self.props.currentTarget.type) &&
@@ -310,14 +320,28 @@ export default class QuestionForm extends OpenStadComponent {
             <OpenStadComponentForms.Select config={{choices: [{value: "false", description: "Nee"}, {value: "true", description: "Ja"}]}} value={self.props.currentTarget.validation && self.props.currentTarget.validation.required} onChange={data => self.handleFieldChange({validation: {required: data.value}})} />
           </div>
         }
+  
+        {
+          self.props.currentTarget.type == 'multiple-choice' &&
+          <div>
+            <h3>Toon "Anders, namelijk:" optie</h3>
+            <OpenStadComponentForms.Select config={{choices: [{value: "false", description: "Nee"}, {value: "true", description: "Ja"}]}} value={self.props.currentTarget.extraConfig && self.props.currentTarget.extraConfig.showOther} onChange={data => self.handleFieldChange({extraConfig: {showOther: data.value}})} />
+            <h3>Minimaal aantal keuzes</h3>
+            <em>Laat leeg of vul '0' in om geen minimum op te geven</em>
+            <OpenStadComponentForms.Text value={self.props.currentTarget.validation && self.props.currentTarget.validation.minChoices || ''} onChange={data => self.handleFieldChange({validation: {minChoices: data.value}})} />
+            <h3>Maximaal aantal keuzes</h3>
+            <em>Laat leeg of vul '0' in om geen maximum op te geven</em>
+            <OpenStadComponentForms.Text value={self.props.currentTarget.validation && self.props.currentTarget.validation.maxChoices || ''} onChange={data => self.handleFieldChange({validation: {maxChoices: data.value}})} />
+          </div>
+        }
         
         {
           ['input', 'textarea'].includes(self.props.currentTarget.type) &&
           <div>
             <h3>Minimale lengte</h3>
-            <OpenStadComponentForms.InputWithCounter config={{ inputType: 'text', minLength: 1, maxLength: 255 }} value={self.props.currentTarget.validation && self.props.currentTarget.validation.minLength || 5} onChange={data => self.handleFieldChange({validation: {minLength: data.value}})} />
+            <OpenStadComponentForms.Text value={self.props.currentTarget.validation && self.props.currentTarget.validation.minLength || 5} onChange={data => self.handleFieldChange({validation: {minLength: data.value}})} />
             <h3>Maximale lengte</h3>
-            <OpenStadComponentForms.InputWithCounter config={{ inputType: 'text', minLength: 1, maxLength: 255 }} value={self.props.currentTarget.validation && self.props.currentTarget.validation.maxLength || 1024} onChange={data => self.handleFieldChange({validation: {maxLength: data.value}})} />
+            <OpenStadComponentForms.Text value={self.props.currentTarget.validation && self.props.currentTarget.validation.maxLength || 1024} onChange={data => self.handleFieldChange({validation: {maxLength: data.value}})} />
           </div>
         }
         

--- a/src/choices-guide/component/edit/question-form.jsx
+++ b/src/choices-guide/component/edit/question-form.jsx
@@ -109,9 +109,19 @@ export default class QuestionForm extends OpenStadComponent {
         parsedData.values[data.valueIndex].text = data.valueText;
       }
     }
+    if (typeof data.validation != 'undefined') {
+      if (data.validation.hasOwnProperty('required')) {
+        parsedData = {validation: {required: data.validation.required === 'true' ? 'true' : 'false'}}
+      } else if (data.validation.hasOwnProperty('minLength')) {
+        parsedData = {validation: {minLength: data.validation.minLength}}
+      } else if (data.validation.hasOwnProperty('maxLength')) {
+        parsedData = {validation: {maxLength: data.validation.maxLength}}
+      }
+    }
+    
     parsedData = parsedData || data;
-    self.props.onChange(parsedData)    
-  } 
+    self.props.onChange(parsedData)
+  }
 
   setShowMoreInfoFields(value) {
     let self = this;
@@ -291,8 +301,26 @@ export default class QuestionForm extends OpenStadComponent {
         <OpenStadComponentForms.ImageUpload key="i1" config={{ as: 'json', imageserver: self.config.image.server }} value={self.props.currentTarget.images} onChange={ data => self.props.onChange({ images: data.value }) } ref={el => self.imagesField = el}/>
 
         <h3>Type vraag</h3>
-        <OpenStadComponentForms.Select config={{ choices: [{ value: "", description: "Maak een keuze" },/*{ value: "continuous", description: "continue" },*/{ value: "a-to-b", description: "van a naar b slider" },/*{ value: "enum-buttons", description: "multiple choice - buttons" }*/,{ value: "enum-radio", description: "radio buttons" }], required: true  }} value={ self.props.currentTarget.type } onChange={ data => self.handleFieldChange({ type: data.value }) } ref={el => self.typeField = el}/>
-
+        <OpenStadComponentForms.Select config={{ choices: [{ value: "", description: "Maak een keuze" },/*{ value: "continuous", description: "continue" },*/{ value: "a-to-b", description: "van a naar b slider" },/*{ value: "enum-buttons", description: "multiple choice - buttons" }*/,{ value: "enum-radio", description: "radio buttons" }, { value: "input", description: "eenvoudige tekstinput" }, { value: "textarea", description: "groot tekstveld" }, { value: "multiple-choice", description: "multiple choice" }], required: true  }} value={ self.props.currentTarget.type } onChange={ data => self.handleFieldChange({ type: data.value }) } ref={el => self.typeField = el}/>
+  
+        {
+          ['enum-radio', 'multiple-choice', 'input', 'textarea'].includes(self.props.currentTarget.type) &&
+          <div>
+            <h3>Verplicht veld?</h3>
+            <OpenStadComponentForms.Select config={{choices: [{value: "false", description: "Nee"}, {value: "true", description: "Ja"}]}} value={self.props.currentTarget.validation && self.props.currentTarget.validation.required} onChange={data => self.handleFieldChange({validation: {required: data.value}})} />
+          </div>
+        }
+        
+        {
+          ['input', 'textarea'].includes(self.props.currentTarget.type) &&
+          <div>
+            <h3>Minimale lengte</h3>
+            <OpenStadComponentForms.InputWithCounter config={{ inputType: 'text', minLength: 1, maxLength: 255 }} value={self.props.currentTarget.validation && self.props.currentTarget.validation.minLength || 5} onChange={data => self.handleFieldChange({validation: {minLength: data.value}})} />
+            <h3>Maximale lengte</h3>
+            <OpenStadComponentForms.InputWithCounter config={{ inputType: 'text', minLength: 1, maxLength: 255 }} value={self.props.currentTarget.validation && self.props.currentTarget.validation.maxLength || 1024} onChange={data => self.handleFieldChange({validation: {maxLength: data.value}})} />
+          </div>
+        }
+        
         {valuesHTML}
         {dimensionsHTML}
         

--- a/src/choices-guide/component/edit/question-form.jsx
+++ b/src/choices-guide/component/edit/question-form.jsx
@@ -205,7 +205,7 @@ export default class QuestionForm extends OpenStadComponent {
         </div>);
     }
 
-    if (self.props.currentTarget.type == 'enum-buttons' || self.props.currentTarget.type == 'enum-radio') {
+    if (self.props.currentTarget.type == 'enum-buttons' || self.props.currentTarget.type == 'enum-radio' || self.props.currentTarget.type == 'multiple-choice') {
 
       let dimensions = self.props.currentTarget.dimensions || "['x']";
       

--- a/src/choices-guide/component/question.jsx
+++ b/src/choices-guide/component/question.jsx
@@ -381,7 +381,7 @@ export default class OpenStadComponentQuestion extends OpenStadComponent {
           <div className="osc-question-selector">
             <div className="osc-radio-container">
                   <div className={`osc-text-input`}>
-                    <OpenStadComponentForms.InputWithCounter config={{ inputType: 'input', ...data.validation }} value={value} onChange={ data => self.onChangeHandler(data.value, false) } ref={el => self.titleField = el}/>
+                    <OpenStadComponentForms.InputWithCounter config={{ inputType: 'input', validation: data.validation, ...data.validation }} value={value} onChange={ data => self.onChangeHandler(data.value, false) } ref={el => self.titleField = el}/>
                   </div>
                   <div className="osc-text-text">{data.values.text}</div>
                 </div>
@@ -394,7 +394,7 @@ export default class OpenStadComponentQuestion extends OpenStadComponent {
           <div className="osc-question-selector">
             <div className="osc-radio-container">
                   <div className={`osc-text-input`}>
-                    <OpenStadComponentForms.InputWithCounter config={{ inputType: 'textarea', ...data.validation }} value={value} onChange={ data => self.onChangeHandler(data.value, false) } ref={el => self.titleField = el}/>
+                    <OpenStadComponentForms.InputWithCounter config={{ inputType: 'textarea', validation: data.validation, ...data.validation }} value={value} onChange={ data => self.onChangeHandler(data.value, false) } ref={el => self.titleField = el}/>
                   </div>
                   <div className="osc-text-text">{data.values.text}</div>
                 </div>

--- a/src/choices-guide/component/question.jsx
+++ b/src/choices-guide/component/question.jsx
@@ -44,6 +44,7 @@ export default class OpenStadComponentQuestion extends OpenStadComponent {
   }
   
   onMultipleChoiceChangeHandler(newState) {
+    newState.error = undefined;
     this.setState(newState, () => {
       this.liveUpdates();
     });
@@ -73,6 +74,23 @@ export default class OpenStadComponentQuestion extends OpenStadComponent {
     if (data.validation && data.validation.maxLength && String(this.state.value).length > data.validation.maxLength) {
       this.setState({error: `Voer maximaal ${data.validation.maxLength} tekens in`});
       return false;
+    }
+    
+    if (['multiple-choice'].includes(data.type)) {
+      let checked = this.state.checked.reduce((count, checked) => count += (checked ? 1 : 0));
+      if (this.state.checkedOther) {
+          checked++;
+      }
+      
+      if (data.validation && data.validation.minChoices > 0 && checked < data.validation.minChoices) {
+        this.setState({error: `Geef minimaal ${data.validation.minChoices} keuzes op`});
+        return false;
+      }
+      
+      if (data.validation && data.validation.maxChoices > 0 && checked > data.validation.maxChoices) {
+        this.setState({error: `Geef maximaal ${data.validation.maxChoices} keuzes op`});
+        return false;
+      }
     }
     
     let isAnswered = this.state.isAnswered || !!this.config.startWithAllQuestionsAnsweredAndConfirmed
@@ -387,7 +405,7 @@ export default class OpenStadComponentQuestion extends OpenStadComponent {
       case 'multiple-choice':
         selectorHTML = (
           <div className="osc-question-selector">
-            <OpenStadComponentForms.Checkboxes config={{ id: data.id, choices: data.values, showOtherInputField: true }} value={value} onChange={ newState => self.onMultipleChoiceChangeHandler(newState)} ref={el => self.titleField = el}/>
+            <OpenStadComponentForms.Checkboxes config={{ id: data.id, choices: data.values, showOtherInputField: data.extraConfig && data.extraConfig.showOther === 'true' ? true : false, validation: data.validation }} value={value} onChange={ newState => self.onMultipleChoiceChangeHandler(newState)} ref={el => self.titleField = el}/>
           </div>
         );
         break;

--- a/src/choices-guide/component/question.jsx
+++ b/src/choices-guide/component/question.jsx
@@ -57,7 +57,7 @@ export default class OpenStadComponentQuestion extends OpenStadComponent {
     let data = this.props.data || {};
     let wasAlreadyAnswered = typeof data.value != 'undefined';
     
-    if (data.validation && data.validation.required === 'true' && (!this.state.value || this.state.value.length <= 0)) {
+    if (data.validation && data.validation.required === 'true' && (!this.state.value || this.state.value.length <= 0) && !['multiple-choice'].includes(data.type)) {
       if (['input', 'textarea'].includes(data.type)) {
         this.setState({error: 'Dit veld is verplicht'});
       } else {
@@ -91,10 +91,16 @@ export default class OpenStadComponentQuestion extends OpenStadComponent {
         this.setState({error: `Geef maximaal ${data.validation.maxChoices} keuzes op`});
         return false;
       }
+      
+      return true;
     }
     
     let isAnswered = this.state.isAnswered || !!this.config.startWithAllQuestionsAnsweredAndConfirmed
     if (wasAlreadyAnswered || isAnswered) return true;
+    
+    if (['input', 'textarea'].includes(data.type)) {
+      return true;
+    }
 
     this.setState({error: 'Je hebt nog geen keuze gemaakt'});
     return false;

--- a/src/choices-guide/component/question.jsx
+++ b/src/choices-guide/component/question.jsx
@@ -101,6 +101,10 @@ export default class OpenStadComponentQuestion extends OpenStadComponent {
     if (['input', 'textarea'].includes(data.type)) {
       return true;
     }
+    
+    if (data.type === 'enum-radio' && data.values.length === 0) {
+      return true;
+    }
 
     this.setState({error: 'Je hebt nog geen keuze gemaakt'});
     return false;
@@ -348,7 +352,7 @@ export default class OpenStadComponentQuestion extends OpenStadComponent {
       case 'enum-radio':
         selectorHTML = (
           <div className="osc-question-selector">
-            { data.values && data.values.map((entry, i) => {
+            { data.values && Array.isArray(data.values) && data.values.map((entry, i) => {
               let key = parseInt(1000000 * Math.random());
               let checked = false;
               if (typeof data.value == 'object') {

--- a/src/choices-guide/css/questions.less
+++ b/src/choices-guide/css/questions.less
@@ -68,66 +68,6 @@
 
     }
 
-    .osc-radio-container, .osc-checkbox-container {
-
-      margin-bottom: 10px;
-      overflow: hidden;
-
-      input[type="radio"], input[type="checkbox"] {
-        opacity: 0;
-        width: 24px;
-        height: 24px;
-        margin: 0;
-        padding: 0;
-      }
-
-      .osc-radio-input, .osc-checkbox-input {
-        position: relative;
-        float: left;
-        width: 24px;
-        height: 24px;
-        margin-right: 12px;
-        border: solid 1px #767676;
-        border-radius: 12px;
-        background-color: white;
-
-        &.osc-checkbox-input {
-          border-radius: 0px;
-        }
-
-
-        &.osc-radio-input-checked, &.osc-checkbox-input-checked {
-
-          &:after {
-            position: absolute;
-            top: 2px;
-            left: 2px;
-            width: 0px;
-            height: 0px;
-            border: solid 9px black;
-            border-radius: 9px;
-            content: '';
-            pointer-events: none;
-          }
-        }
-
-        &.osc-checkbox-input-checked:after {
-          border-radius: 0px;
-        }
-      }
-
-      .osc-radio-text, .osc-checkbox-text {
-        float: left;
-        width: calc(100% - 37px);
-        line-height: 1.38;
-      }
-
-    }
-
-    .osc-other-textinput {
-      margin-left: 34px;
-    }
-
     &.osc-question-a-to-b {
 
       .osc-question-description {
@@ -211,4 +151,63 @@
 
 
   }
+}
+
+.osc-radio-container, .osc-checkbox-container {
+  margin-bottom: 10px;
+  overflow: hidden;
+
+  input[type="radio"], input[type="checkbox"] {
+    opacity: 0;
+    width: 24px;
+    height: 24px;
+    margin: 0;
+    padding: 0;
+  }
+
+  .osc-radio-input, .osc-checkbox-input {
+    position: relative;
+    float: left;
+    width: 24px;
+    height: 24px;
+    margin-right: 12px;
+    border: solid 1px #767676;
+    border-radius: 12px;
+    background-color: white;
+
+    &.osc-checkbox-input {
+      border-radius: 0px;
+    }
+
+
+    &.osc-radio-input-checked, &.osc-checkbox-input-checked {
+
+      &:after {
+        position: absolute;
+        top: 2px;
+        left: 2px;
+        width: 0px;
+        height: 0px;
+        border: solid 9px black;
+        border-radius: 9px;
+        content: '';
+        pointer-events: none;
+      }
+    }
+
+    &.osc-checkbox-input-checked:after {
+      border-radius: 0px;
+    }
+  }
+
+  .osc-radio-text, .osc-checkbox-text {
+    float: left;
+    width: calc(100% - 37px);
+    line-height: 1.38;
+  }
+
+}
+
+.osc-other-textinput {
+  margin-left: 34px;
 }

--- a/src/choices-guide/css/questions.less
+++ b/src/choices-guide/css/questions.less
@@ -16,7 +16,7 @@
     .osc-accordeon {
       margin-bottom: 30px;
     }
-    
+
     .osc-slider {
       .osc-slider();
     }
@@ -44,7 +44,7 @@
     .osc-question-selector {
 
       overflow:hidden;
-      
+
       .osc-question-selector-slider {
         clear: both;
         width: 100%;
@@ -68,12 +68,12 @@
 
     }
 
-    .osc-radio-container {
+    .osc-radio-container, .osc-checkbox-container {
 
       margin-bottom: 10px;
       overflow: hidden;
 
-      input[type="radio"] {
+      input[type="radio"], input[type="checkbox"] {
         opacity: 0;
         width: 24px;
         height: 24px;
@@ -81,7 +81,7 @@
         padding: 0;
       }
 
-      .osc-radio-input {
+      .osc-radio-input, .osc-checkbox-input {
         position: relative;
         float: left;
         width: 24px;
@@ -91,8 +91,12 @@
         border-radius: 12px;
         background-color: white;
 
+        &.osc-checkbox-input {
+          border-radius: 0px;
+        }
 
-        &.osc-radio-input-checked {
+
+        &.osc-radio-input-checked, &.osc-checkbox-input-checked {
 
           &:after {
             position: absolute;
@@ -103,17 +107,25 @@
             border: solid 9px black;
             border-radius: 9px;
             content: '';
+            pointer-events: none;
           }
         }
 
+        &.osc-checkbox-input-checked:after {
+          border-radius: 0px;
+        }
       }
 
-      .osc-radio-text {
+      .osc-radio-text, .osc-checkbox-text {
         float: left;
         width: calc(100% - 37px);
         line-height: 1.38;
       }
 
+    }
+
+    .osc-other-textinput {
+      margin-left: 34px;
     }
 
     &.osc-question-a-to-b {

--- a/src/forms/component/checkboxes.jsx
+++ b/src/forms/component/checkboxes.jsx
@@ -92,6 +92,20 @@ export default class OpenStadComponentCheckboxes extends OpenStadComponentDefaul
         });
     }
     
+    validate({ showErrors }) {
+        let isValid = false;
+        if (this.config.validation && this.config.validation.required === 'true') {
+            isValid = this.state.checked.some((check) => !!check) || (this.state.checkedOther && this.state.otherInputValue.length > 0);
+        } else {
+            isValid = true;
+        }
+        
+        let error = '';
+        if (!isValid && showErrors) error = true;
+        this.setState({ isValid, error })
+		return isValid;
+	}
+    
     render() {
         const choices   = this.props.config.choices || [];
         const showOther = this.props.config.showOtherInputField;
@@ -116,7 +130,7 @@ export default class OpenStadComponentCheckboxes extends OpenStadComponentDefaul
                             />
                         </div>
                         <div className="osc-checkbox-text"><label
-                            for={`enum-checkbox-${id}-${key}`}>{this.otherText}</label>
+                            htmlFor={`enum-checkbox-${id}-${key}`}>{this.otherText}</label>
                         </div>
                     </div>
                     {checked && (
@@ -146,7 +160,7 @@ export default class OpenStadComponentCheckboxes extends OpenStadComponentDefaul
                                        key={`button-value-${id}-${key}`}
                                 />
                             </div>
-                            <div className="osc-checkbox-text"><label for={`enum-checkbox-${id}-${key}`}>{text}</label>
+                            <div className="osc-checkbox-text"><label htmlFor={`enum-checkbox-${id}-${key}`}>{text}</label>
                             </div>
                         </div>
                     )

--- a/src/forms/component/checkboxes.jsx
+++ b/src/forms/component/checkboxes.jsx
@@ -82,6 +82,7 @@ export default class OpenStadComponentCheckboxes extends OpenStadComponentDefaul
     
     handleOnChangeOtherCheckbox() {
         this.setState({checkedOther: !this.state.checkedOther}, () => {
+            this.validate({});
             this.triggerParentOnChange();
         });
     }

--- a/src/forms/component/checkboxes.jsx
+++ b/src/forms/component/checkboxes.jsx
@@ -1,0 +1,159 @@
+'use strict';
+
+import OpenStadComponentDefaultInput from "./default-input.jsx";
+import OpenStadComponentForms from '../../forms/index.jsx';
+
+export default class OpenStadComponentCheckboxes extends OpenStadComponentDefaultInput {
+    
+    constructor(props, defaultConfig = {}) {
+        
+        super(props, {
+            config: {
+                choices:             [],
+                showOtherInputField: true,
+                id:                  ''
+            },
+        }, defaultConfig);
+        
+        let values = [];
+        
+        this.props.config.choices.forEach((text, index) => {
+            values[index] = text;
+        });
+        
+        this.state = {
+            checked:         new Array(props.config.choices.length).fill(false),
+            values:          values,
+            checkedOther:    false,
+            otherInputValue: ''
+        };
+        
+        this.onChange = props.onChange;
+        
+        this.otherText = 'Anders, namelijk: ';
+        
+    }
+    
+    componentDidMount() {
+        if (this.props.value) {
+            let newState     = {};
+            newState.checked = this.state.checked;
+            // Set correct state based on value
+            this.props.value.forEach((value) => {
+                if (value.indexOf(this.otherText) === 0) {
+                    newState.checkedOther    = true;
+                    newState.otherInputValue = value.substr(this.otherText.length)
+                } else {
+                    const index = this.state.values.findIndex(stateValue => stateValue.text == value);
+                    
+                    if (index > -1) {
+                        newState.checked[index] = true;
+                    }
+                }
+            })
+            
+            this.setState(newState, () => {
+                this.triggerParentOnChange();
+            })
+        }
+    }
+    
+    triggerParentOnChange() {
+        if (typeof this.onChange == 'function') {
+            this.onChange({
+                isAnswered:      (this.state.checkedOther && this.state.otherInputValue) || this.state.checked.some((isChecked) => isChecked === true),
+                name:            this.config.name,
+                checked:         this.state.checked,
+                values:          this.state.values,
+                checkedOther:    this.state.checkedOther,
+                otherInputValue: this.state.otherInputValue
+            });
+        }
+    }
+    
+    handleOnChange(position) {
+        const updatedCheckedState = this.state.checked.map((item, index) => index === position ? !item : item);
+        
+        this.setState({checked: updatedCheckedState}, () => {
+            this.validate({});
+            this.triggerParentOnChange();
+        });
+    }
+    
+    handleOnChangeOtherCheckbox() {
+        this.setState({checkedOther: !this.state.checkedOther}, () => {
+            this.triggerParentOnChange();
+        });
+    }
+    
+    handleOnChangeOtherInput({value}) {
+        this.setState({otherInputValue: value}, () => {
+            this.triggerParentOnChange();
+        });
+    }
+    
+    render() {
+        const choices   = this.props.config.choices || [];
+        const showOther = this.props.config.showOtherInputField;
+        const id        = this.props.config.id;
+        
+        let otherHtml = '';
+        
+        if (showOther) {
+            const key     = parseInt(1000000 * Math.random());
+            const checked = this.state.checkedOther;
+            
+            otherHtml = (
+                <div>
+                    <div key={`div-value-${id}-${key}`} className="osc-checkbox-container">
+                        <div className={`osc-checkbox-input${checked ? ' osc-checkbox-input-checked' : ''}`}>
+                            <input type="checkbox"
+                                   name={`enum-checkbox-${id}-${key}`}
+                                   id={`enum-checkbox-${id}-${key}`}
+                                   defaultChecked={checked}
+                                   onChange={() => this.handleOnChangeOtherCheckbox()} value={this.otherText}
+                                   key={`button-value-${id}-${key}`}
+                            />
+                        </div>
+                        <div className="osc-checkbox-text"><label
+                            for={`enum-checkbox-${id}-${key}`}>{this.otherText}</label>
+                        </div>
+                    </div>
+                    {checked && (
+                        <OpenStadComponentForms.Text autoFocus placeholder={this.otherText}
+                                                     value={this.state.otherInputValue}
+                                                     className="osc-other-textinput" required="true"
+                                                     onChange={data => this.handleOnChangeOtherInput(data)}/>
+                    )}
+                </div>
+            )
+        }
+        
+        return (
+            <div className="osc-question-selector">
+                {choices && choices.map(({value, text}, index) => {
+                    const key     = parseInt(1000000 * Math.random());
+                    const checked = this.state.checked[index] || false;
+                    
+                    return (
+                        <div key={`div-value-${id}-${key}`} className="osc-checkbox-container">
+                            <div className={`osc-checkbox-input${checked ? ' osc-checkbox-input-checked' : ''}`}>
+                                <input type="checkbox"
+                                       name={`enum-checkbox-${id}-${key}`}
+                                       id={`enum-checkbox-${id}-${key}`}
+                                       defaultChecked={checked}
+                                       onChange={() => this.handleOnChange(index)} value={text}
+                                       key={`button-value-${id}-${key}`}
+                                />
+                            </div>
+                            <div className="osc-checkbox-text"><label for={`enum-checkbox-${id}-${key}`}>{text}</label>
+                            </div>
+                        </div>
+                    )
+                })}
+                {showOther && otherHtml}
+            </div>
+        )
+    }
+    
+}

--- a/src/forms/component/form-field.jsx
+++ b/src/forms/component/form-field.jsx
@@ -11,6 +11,7 @@ import OpenStadComponentPostcode from './postcode.jsx';
 import OpenStadComponentSelect from './select.jsx';
 import OpenStadComponentText from './textinput.jsx';
 import OpenStadComponentTextArea from './textarea.jsx';
+import OpenStadComponentCheckboxes from './checkboxes.jsx';
 
 export default class OpenStadComponentFormField extends OpenStadComponent {
 
@@ -57,6 +58,27 @@ export default class OpenStadComponentFormField extends OpenStadComponent {
 			this.onChange(data);
 		}
 	}
+    
+    onMultipleChoiceChangeHandler(data) {
+      
+      let values = [];
+      
+      data.checked.forEach((val, index) => {
+        if (val === true) {
+          values.push(data.values[index].text);
+        }
+      });
+      
+      if (data.checkedOther === true) {
+        values.push(`Anders, namelijk: ${data.otherInputValue}`);
+      }
+      
+      let newState = {name: this.config.name, value: values};
+      
+      if (typeof this.onChange == 'function') {
+          this.onChange(newState);
+      }
+    }
 
 	render() {
 
@@ -103,8 +125,15 @@ export default class OpenStadComponentFormField extends OpenStadComponent {
         break;
 
       case 'select':
-      case 'multiple-choice':
         fieldHTML = <OpenStadComponentSelect config={self.config} value={ this.state.value } onChange={self.handleOnChange} ref={el => (self.input = el)}/>
+        break;
+        
+      case 'multiple-choice':
+        const choices = self.config.choices.map((choice) => { choice.text = choice.title; return choice; });
+        const showOtherInputField = self.config.showOther || false;
+        const value = Array.isArray(this.state.value) ? this.state.value : (typeof this.state.value != 'undefined' ? [this.state.value] : []);
+        
+        fieldHTML = <OpenStadComponentCheckboxes config={{ showOtherInputField, choices }} value={ value } onChange={ newState => self.onMultipleChoiceChangeHandler(newState)} ref={el => (self.input = el)}/>
         break;
 
       case 'text':

--- a/src/forms/component/form-field.jsx
+++ b/src/forms/component/form-field.jsx
@@ -133,7 +133,7 @@ export default class OpenStadComponentFormField extends OpenStadComponent {
         const showOtherInputField = self.config.showOther || false;
         const value = Array.isArray(this.state.value) ? this.state.value : (typeof this.state.value != 'undefined' ? [this.state.value] : []);
         
-        fieldHTML = <OpenStadComponentCheckboxes config={{ showOtherInputField, choices }} value={ value } onChange={ newState => self.onMultipleChoiceChangeHandler(newState)} ref={el => (self.input = el)}/>
+        fieldHTML = <OpenStadComponentCheckboxes config={{ showOtherInputField, choices, ...self.config }} value={ value } onChange={ newState => self.onMultipleChoiceChangeHandler(newState)} ref={el => (self.input = el)}/>
         break;
 
       case 'text':

--- a/src/forms/component/form.jsx
+++ b/src/forms/component/form.jsx
@@ -45,14 +45,14 @@ export default class OpenStadComponentForm extends OpenStadComponent {
     let isValid = true;
     let firstInvalid = null
     self.fields.forEach((field) => {
-      if (!field.validate({ showErrors })) { 
+      if (!field.validate({ showErrors })) {
         isValid = false;
         if (!firstInvalid) firstInvalid = field;
       }
     });
 
     if (scrollTo && firstInvalid && firstInvalid.instance && firstInvalid.instance.scrollIntoView) firstInvalid.instance.scrollIntoView({behavior: 'smooth'});
-    return isValid;    
+    return isValid;
 
 	}
 

--- a/src/forms/component/input-with-counter.jsx
+++ b/src/forms/component/input-with-counter.jsx
@@ -15,7 +15,8 @@ export default class FormfieldInputWithCounter extends OpenStadComponent {
 			inputType: 'input',
 			minLength: 5,
 			maxLength: 1024,
-      placeholder: '',
+			required: false,
+      		placeholder: '',
 		});
 
 		let self = this;
@@ -58,7 +59,7 @@ export default class FormfieldInputWithCounter extends OpenStadComponent {
 		this.setState({ showWarning: true })
 		return this.isValid();
 	}
-  
+ 
 	handleOnChange(data) {
     data = data || {};
 		this.setState(data, () => {
@@ -95,11 +96,12 @@ export default class FormfieldInputWithCounter extends OpenStadComponent {
 		let counter = null;
 		let warning = null;
 		if (self.state.focused) {
-			if (self.state.value.length < self.config.minLength) {
-				counter = (<div className="osc-form-counter osc-form-error">Nog minimaal <span className="">{self.config.minLength - self.state.value.length}</span> tekens</div>)
+			const currentValueLength = String(self.state.value).length;
+			if (currentValueLength < self.config.minLength) {
+				counter = (<div className="osc-form-counter osc-form-error">Nog minimaal <span className="">{self.config.minLength - currentValueLength}</span> tekens</div>)
 			} else {
-				let error = self.state.value.length > self.config.maxLength ? 'osc-form-error' : '';
-				counter = (<div className={'osc-form-counter ' + error}>Je hebt nog <span className="">{self.config.maxLength - self.state.value.length}</span> tekens over.</div>)
+				let error = currentValueLength > self.config.maxLength ? 'osc-form-error' : '';
+				counter = (<div className={'osc-form-counter ' + error}>Je hebt nog <span className="">{self.config.maxLength - currentValueLength}</span> tekens over.</div>)
 			}
 		}
 
@@ -110,7 +112,7 @@ export default class FormfieldInputWithCounter extends OpenStadComponent {
     let inputHTML = null;
 
     switch(self.config.inputType) {
-        
+      
       case 'htmlarea':
         inputHTML = (
           <HTMLArea
@@ -141,14 +143,14 @@ export default class FormfieldInputWithCounter extends OpenStadComponent {
         
       case 'textarea':
         inputHTML = (
-				  <textarea key={self.key} ref={el => (self.input = el)} value={this.state.value} disabled={this.props.disabled} placeholder={this.config.placeholder} onChange={e => self.handleOnChange({ value: self.input.value })} onKeyUp={e => self.onInputKeyUp()} onFocus={e => self.onInputFocus(e)} onBlur={e => self.onInputBlur(e)}></textarea>
+				  <textarea key={self.key} ref={el => (self.input = el)} value={this.state.value} disabled={this.props.disabled} placeholder={this.config.placeholder} required={this.config.required} onChange={e => self.handleOnChange({ value: self.input.value })} onKeyUp={e => self.onInputKeyUp()} onFocus={e => self.onInputFocus(e)} onBlur={e => self.onInputBlur(e)}></textarea>
         );
         break;
 
       case 'input':
       default:
         inputHTML = (
-				  <input key={self.key} ref={el => (self.input = el)} value={this.state.value} disabled={this.props.disabled} placeholder={this.config.placeholder} onChange={e => self.handleOnChange({ value: self.input.value })} onKeyUp={e => self.onInputKeyUp()} onFocus={e => self.onInputFocus(e)} onBlur={e => self.onInputBlur(e)}></input>
+				  <input key={self.key} ref={el => (self.input = el)} value={this.state.value} disabled={this.props.disabled} placeholder={this.config.placeholder} required={this.config.required} onChange={e => self.handleOnChange({ value: self.input.value })} onKeyUp={e => self.onInputKeyUp()} onFocus={e => self.onInputFocus(e)} onBlur={e => self.onInputBlur(e)}></input>
         );
 
     }

--- a/src/forms/component/slider.jsx
+++ b/src/forms/component/slider.jsx
@@ -33,6 +33,10 @@ class Slider extends OpenStadComponent {
   }
 
   calcProgress(min, max, value) {
+    if (typeof value === 'undefined') {
+      return 0;
+    }
+    
     const range = max - min
     const progInRange = value - min
     return ((progInRange*2)/range)-1

--- a/src/forms/component/textinput.jsx
+++ b/src/forms/component/textinput.jsx
@@ -5,17 +5,18 @@ import OpenStadComponentDefaultInput from './default-input.jsx';
 export default class OpenStadComponentText extends OpenStadComponentDefaultInput {
 
 	render() {
-
-		let self = this;
-
+    
     let errorHTML = null;
-    if (self.state.error) {
+    if (this.state.error) {
       errorHTML = (<div className="osc-form-error osc-form-field-error">Je hebt nog niets ingevuld</div>)
     }
     
+    const className = this.props.className ? "osc-textinput " + this.props.className : "osc-textinput";
+    const autoFocus = this.props.autoFocus ? true : false;
+    
     return (
-			<div className="osc-textinput">
-			  <input type="text" value={this.state.value} disabled={this.props.disabled} placeholder={this.config.placeholder} onChange={e => self.handleOnChange({ value: self.input.value })} ref={el => (self.input = el)}/>
+			<div className={className}>
+			  <input type="text" value={this.state.value} autoFocus={autoFocus} disabled={this.props.disabled} placeholder={this.config.placeholder} required={this.props.required} onChange={e => this.handleOnChange({ value: this.input.value })} ref={el => (this.input = el)}/>
         {errorHTML}
 		  </div>
     );

--- a/src/forms/css/default.less
+++ b/src/forms/css/default.less
@@ -95,3 +95,7 @@
   }
 
 }
+
+.osc-result-content .osc-input-with-counter .osc-form-warning {
+  display: none;
+}

--- a/src/forms/index.jsx
+++ b/src/forms/index.jsx
@@ -22,6 +22,7 @@ import Select from './component/select.jsx';
 import Text from './component/textinput.jsx';
 import Textarea from './component/textarea.jsx';
 import Slider from './component/slider.jsx';
+import Checkboxes from './component/checkboxes.jsx';
 export default {
   Form,
   FormField,
@@ -34,6 +35,7 @@ export default {
   Text,
   Textarea,
   Slider,
+  Checkboxes,
 }
 
 // render the base element


### PR DESCRIPTION
- Add `textarea`,`input` and `multiple-choice` types
- Add `validation` object to Choices Guide Question, which allows `required` (boolean), `minLength` (number), `maxLength` (number). These attributes will be used in the question's `isValid(...)` call.